### PR TITLE
fix close_checkbox function

### DIFF
--- a/patzilla-ui/navigator/components/stack/stack-core.js
+++ b/patzilla-ui/navigator/components/stack/stack-core.js
@@ -195,7 +195,10 @@ const StackManager = NamedViewController.extend({
         this.view.region_stack_checkbox.show(this.checkbox_widget);
     },
     close_checkbox: function() {
-        this.view.region_stack_checkbox.reset();
+        var region_stack_checkbox = this.view.region_stack_checkbox;
+        if (region_stack_checkbox) {
+            region_stack_checkbox.reset();
+        }
     },
 
     // Debugging helpers


### PR DESCRIPTION
Fix error `TypeError: this.view.region_stack_checkbox is undefined` when you: select document -> make a new search(selected checkbox is not on the page anymore) -> click "reset" button to reset all selected documents